### PR TITLE
added Jamfile.v2

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -1,0 +1,24 @@
+# (C) Copyright 2016 Klemens D. Morgenstern
+# Distributed under the Boost Software License, Version 1.0. (See accompanying 
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)
+
+# See http://www.boost.org/libs/iostreams for documentation.
+
+project /boost/histogram : source-location ../src ;
+
+# For each library with either link to existing binary, or build
+# a library from th
+
+import python ;
+
+lib boost_histogram : axis.cpp basic_histogram.cpp histogram.cpp nstore.cpp zero_suppression.cpp ;
+
+lib boost_pyhistogram : 
+                        python/axis.cpp 
+                        python/basic_histogram.cpp 
+                        python/histogram.cpp 
+                        python/module.cpp 
+                        /python//python_for_extensions  ;
+                        
+boost-install boost_histogram boost_pyhistogram  ;
+

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,4 +1,4 @@
-# Copyright David Abrahams 2006. Distributed under the Boost
+# Copyright Klemens David Morgenstern 2016. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,0 +1,29 @@
+# Copyright David Abrahams 2006. Distributed under the Boost
+# Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+
+#use-project /boost/histogram : ../build ;
+
+project 
+  : requirements
+    <target-os>windows:<define>WIN32_LEAN_AND_MEAN
+    <target-os>linux:<linkflags>-lpthread
+  ;
+
+  
+import testing ;
+import python ;
+import os ;
+
+test-suite ts : 
+    [ compile check/sizeof.cpp ]
+    #[ compile check/speed_vs_root.cpp ] //not in yet, cause it needs an external library
+    [ run axis_test.cpp             /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]
+    [ run histogram_test.cpp        /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]
+    [ run nstore_test.cpp           /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]
+    [ run zero_suppression_test.cpp /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]
+    ;
+  
+ 


### PR DESCRIPTION
Grüß Gott Hans,

I added the bjam support for the library, though it does not include the python test (python_suite_test.py.in) and speed_vs_root.cpp.

I hope that helps. If you want to build it, you just clone the histogram library into boost/libs and then the depencies should work out fine. 

LG,

Klemens