### PR TITLE
Cleanup & Serialization

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -1,0 +1,24 @@
+# (C) Copyright 2016 Klemens D. Morgenstern
+# Distributed under the Boost Software License, Version 1.0. (See accompanying 
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)
+
+# See http://www.boost.org/libs/iostreams for documentation.
+
+project /boost/histogram : source-location ../src ;
+
+# For each library with either link to existing binary, or build
+# a library from th
+
+import python ;
+
+lib boost_histogram : axis.cpp basic_histogram.cpp histogram.cpp nstore.cpp zero_suppression.cpp ;
+
+lib boost_pyhistogram : 
+                        python/axis.cpp 
+                        python/basic_histogram.cpp 
+                        python/histogram.cpp 
+                        python/module.cpp 
+                        /python//python_for_extensions  ;
+                        
+boost-install boost_histogram boost_pyhistogram  ;
+

--- a/doc/Jamfile.jam
+++ b/doc/Jamfile.jam
@@ -1,0 +1,27 @@
+# Copyright (c) 2016 Klemens D. Morgenstern
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+using boostbook ;
+using quickbook ;
+using doxygen ;
+
+doxygen autodoc
+:
+  ../../../boost/histogram.hpp
+  [ glob ../../../boost/histogram/*.hpp ]
+:
+  <doxygen:param>PREDEFINED=BOOST_HISTOGRAM_DOXYGEN
+  <doxygen:param>HIDE_UNDOC_CLASSES=YES
+  <doxygen:param>HIDE_UNDOC_MEMBERS=YES
+;
+
+boostbook standalone
+:
+  histogram.qbk
+:
+  <dependency>autodoc
+  <xsl:param>boost.root=../../../..
+  <xml:param>html.stylesheet=../../../../doc/src/boostbook.css
+;

--- a/doc/histogram.qbk
+++ b/doc/histogram.qbk
@@ -1,0 +1,55 @@
+[library Boost.Histogram
+    [quickbook 1.5]
+    [authors [Dembinski, Hans]]
+    [copyright 2016 Hand Dembinski]
+    [id histogram]
+    [dirname histogram]
+    [license
+        Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+        http://www.boost.org/LICENSE_1_0.txt)
+    ]
+]
+
+
+[section:descr Description]
+
+This project contains an easy-to-use powerful n-dimensional histogram class implemented in ``C++03``, optimized for convenience and excellent performance under heavy duty. Move semantics are supported using `boost::move`. The histogram has a complete C++ and a `Python <http://www.python.org>`_ interface, and can be passed over the language boundary with ease. `Numpy <http://www.numpy.org>`_ is fully supported; histograms can be filled with Numpy arrays at C speeds and are convertible into Numpy arrays without copying data. Histograms can be streamed from/to files and pickled in Python.
+
+My goal is to submit this project to the `Boost Libraries <http://www.boost.org Boost>`_.
+
+[endsect]
+
+[include motivation.qbk]
+[include intro.qbk]
+[/ [include tutorial.qbk]      ]
+[/ [include notes.qbk]         ]
+[/ [include types.qbk]         ]
+[/ [include rationale.qbk]     ]
+[/ [include references.qbk]    ]
+[/ [include changelog.qbk]     ]
+
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   motivation
+   intro
+   tutorial
+   notes
+   types
+   rationale
+   references
+   changelog
+
+.. Indices and tables
+.. ==================
+
+.. * :ref:`genindex`
+.. * :ref:`modindex`
+.. * :ref:`search`
+
+[xinclude autodoc.xml]
+[include changelog.qbk]

--- a/include/boost/histogram.hpp
+++ b/include/boost/histogram.hpp
@@ -1,0 +1,28 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_HISTOGRAM_HPP_
+#define BOOST_HISTOGRAM_HPP_
+
+#include <boost/histogram/histogram.hpp>
+#include <boost/histogram/serialization.hpp>
+
+/**
+ * \file boost/histogram.hpp
+   \brief Includes all the non-experimental headers of the Boost.histogram library.
+
+   The library consists of a single \ref boost::histogram::histogram "histogram"
+   and several axis types which are stored in a
+   boost::variant called \ref boost::histogram::axis_type "axis_type"
+   The axis types are created and passed to the constructor of the
+   histogram to define its binning scheme.
+   All following types are embedded in the
+   \ref boost::histogram  namespace, which is omitted for brevity.
+
+*/
+
+
+#endif

--- a/include/boost/histogram/axis.hpp
+++ b/include/boost/histogram/axis.hpp
@@ -194,7 +194,7 @@ public:
                const std::string& label = std::string(),
                bool uoflow = true);
 
-  integer_axis() {}
+  integer_axis() : min_(0) {}
   integer_axis(const integer_axis&);
   integer_axis& operator=(const integer_axis&);
 

--- a/include/boost/histogram/axis.hpp
+++ b/include/boost/histogram/axis.hpp
@@ -79,7 +79,7 @@ public:
 
   inline int index(double x) const {
     const double z = (x - min_) / range_;
-    return algorithm::clamp(int(floor(z * bins())), -1, bins());
+    return algorithm::clamp(static_cast<int>(floor(z * bins())), -1, bins());
   }
 
   double operator[](int idx) const;
@@ -112,7 +112,7 @@ public:
   inline int index(double x) const { 
     using namespace boost::math::double_constants;
     const double z = (x - start_) / two_pi;
-    const int i = int(floor(z * bins())) % bins();
+    const int i = static_cast<int>(floor(z * bins())) % bins();
     return i + (i < 0) * bins();
   }
 
@@ -283,7 +283,7 @@ namespace detail {
     void operator()(const category_axis& a) {
       if (k < size_type(-1)) {
         if (use_x)
-          j = int(x + 0.5);
+          j = static_cast<int>(x + 0.5);
         const int bins = a.bins();
         j += (j < 0) * bins; // wrap around if j < 0
         if (j < bins) {

--- a/include/boost/histogram/axis.hpp
+++ b/include/boost/histogram/axis.hpp
@@ -1,12 +1,15 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef _BOOST_HISTOGRAM_AXIS_HPP_
 #define _BOOST_HISTOGRAM_AXIS_HPP_
 
 #include <boost/algorithm/clamp.hpp>
 #include <boost/variant.hpp>
 #include <boost/scoped_array.hpp>
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/base_object.hpp>
-#include <boost/serialization/array.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <string>
 #include <vector>
@@ -37,14 +40,8 @@ private:
   int size_;
   std::string label_;
 
-  friend class serialization::access;
   template <class Archive>
-  void serialize(Archive& ar, unsigned version)
-  {
-    using namespace serialization;
-    ar & size_;
-    ar & label_;
-  }
+  friend void serialize(Archive& ar, axis_base & base, unsigned version);
 };
 
 // mixin for real-valued axes
@@ -73,7 +70,7 @@ public:
                const std::string& label = std::string(),
                bool uoflow = true);
 
-  regular_axis() {}
+  regular_axis() : min_(0), range_(0) {}
   regular_axis(const regular_axis&);
   regular_axis& operator=(const regular_axis&);
 
@@ -87,15 +84,8 @@ public:
 private:
   double min_, range_;
 
-  friend class serialization::access;
   template <class Archive>
-  void serialize(Archive& ar, unsigned version)
-  {
-    using namespace serialization;
-    ar & boost::serialization::base_object<axis_base>(*this);
-    ar & min_;
-    ar & range_;
-  }
+  friend void serialize(Archive& ar, regular_axis & axis ,unsigned version);
 };
 
 // real polar axis (constant bin widths, wraps around)
@@ -105,7 +95,7 @@ public:
   polar_axis(int n, double start = 0.0,
              const std::string& label = std::string());
 
-  polar_axis() {}
+  polar_axis() : start_(0) {}
   polar_axis(const polar_axis&);
   polar_axis& operator=(const polar_axis&);
 
@@ -121,14 +111,8 @@ public:
 private:
   double start_;
 
-  friend class serialization::access;
   template <class Archive>
-  void serialize(Archive& ar, unsigned version)
-  {
-    using namespace serialization;
-    ar & boost::serialization::base_object<axis_base>(*this);
-    ar & start_;
-  }
+  friend void serialize(Archive& ar, polar_axis & axis, unsigned version);
 };
 
 // real variable axis (varying bin widths)
@@ -171,15 +155,8 @@ public:
 private:
   boost::scoped_array<double> x_;
 
-  friend class serialization::access;
   template <class Archive>
-  void serialize(Archive& ar, unsigned version)
-  {
-    ar & boost::serialization::base_object<axis_base>(*this);
-    if (Archive::is_loading::value)
-      x_.reset(new double[bins() + 1]);
-    ar & serialization::make_array(x_.get(), bins() + 1);
-  }
+  friend void serialize(Archive& ar, variable_axis & axis, unsigned version);
 };
 
 class category_axis {
@@ -205,13 +182,8 @@ public:
 private:
   std::vector<std::string> categories_;
 
-  friend class serialization::access;
   template <class Archive>
-  void serialize(Archive& ar, unsigned version)
-  {
-    using namespace serialization;
-    ar & categories_;
-  }
+  friend void serialize(Archive& ar, category_axis & axis, unsigned version);
 };
 
 class integer_axis: public axis_base {
@@ -234,14 +206,8 @@ public:
 private:
   int min_;
 
-  friend class serialization::access;
   template <class Archive>
-  void serialize(Archive& ar, unsigned version)
-  {
-    using namespace serialization;
-    ar & boost::serialization::base_object<axis_base>(*this);
-    ar & min_;
-  }
+  friend void serialize(Archive& ar, integer_axis & axis, unsigned version);
 };
 
 namespace detail {

--- a/include/boost/histogram/basic_histogram.hpp
+++ b/include/boost/histogram/basic_histogram.hpp
@@ -99,12 +99,13 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_BASE_CTOR
     return lin.k;
   }
 
+  template<typename Range>
   inline
-  size_type linearize(const int* idx) const {
+  size_type linearize(const Range &r) const {
     detail::linearize lin(false);
     int i = axes_.size();
     while (i--) {
-      lin.j = idx[i];
+      lin.j = r[i];
       apply_visitor(lin, axes_[i]);
     }
     return lin.k;

--- a/include/boost/histogram/basic_histogram.hpp
+++ b/include/boost/histogram/basic_histogram.hpp
@@ -19,7 +19,9 @@
 
 #include <bitset>
 
+#if !defined(BOOST_HISTOGRAM_AXIS_LIMIT)
 #define BOOST_HISTOGRAM_AXIS_LIMIT 16
+#endif
 
 namespace boost {
 namespace histogram {

--- a/include/boost/histogram/basic_histogram.hpp
+++ b/include/boost/histogram/basic_histogram.hpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef _BOOST_HISTOGRAM_BASE_HPP_
 #define _BOOST_HISTOGRAM_BASE_HPP_
 
@@ -5,10 +11,6 @@
 #include <boost/histogram/visitors.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/preprocessor.hpp>
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/split_member.hpp>
-#include <boost/serialization/variant.hpp>
-#include <boost/serialization/vector.hpp>
 #include <boost/container/static_vector.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
@@ -112,17 +114,8 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_BASE_CTOR
 private:
   axes_type axes_;
 
-  friend class serialization::access;
   template <class Archive>
-  void serialize(Archive& ar, unsigned version)
-  {
-    using namespace serialization;
-    unsigned size = axes_.size();
-    ar & size;
-    if (Archive::is_loading::value)
-      axes_.resize(size);
-    ar & serialization::make_array(&axes_[0], size);
-  }
+  friend void serialize(Archive& ar, basic_histogram & h, unsigned version);
 };
 
 }

--- a/include/boost/histogram/detail/nstore.hpp
+++ b/include/boost/histogram/detail/nstore.hpp
@@ -51,7 +51,7 @@ public:
   {
     if (this != &o) {
       if (size_ == o.size_ && depth_ == o.depth_) {
-        std::memcpy(buffer_, o.buffer_, size_ * int(depth_));
+        std::memcpy(buffer_, o.buffer_, size_ * static_cast<int>(depth_));
       } else {
         destroy();
         size_ = o.size_;

--- a/include/boost/histogram/detail/nstore.hpp
+++ b/include/boost/histogram/detail/nstore.hpp
@@ -139,8 +139,8 @@ private:
   template<typename T>
   bool add_impl_(size_type i, const uint64_t & oi)
   {
-    T& b = ((T*)buffer_)[i];
-    if (T(std::numeric_limits<T>::max() - b) >= oi) {
+    T& b = static_cast<T*>(buffer_)[i];
+    if (static_cast<T>(std::numeric_limits<T>::max() - b) >= oi) {
   	b += oi;
   	return true;
     } else grow(); /* and fall through */

--- a/include/boost/histogram/detail/wtype.hpp
+++ b/include/boost/histogram/detail/wtype.hpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef _BOOST_HISTOGRAM_DETAIL_WTYPE_HPP_
 #define _BOOST_HISTOGRAM_DETAIL_WTYPE_HPP_
 
@@ -25,9 +31,7 @@ struct wtype {
   { return w == o.w && w2 == o.w2; }
   bool operator!=(const wtype& o) const
   { return w != o.w || w2 != o.w2; }
-  template <class Archive>
-  void serialize(Archive& ar, unsigned version)
-  { ar & w; ar & w2; }
+
 };
 
 static

--- a/include/boost/histogram/detail/zero_suppression.hpp
+++ b/include/boost/histogram/detail/zero_suppression.hpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef _BOOST_HISTOGRAM_DETAIL_ZERO_SUPPRESSION_HPP_
 #define _BOOST_HISTOGRAM_DETAIL_ZERO_SUPPRESSION_HPP_
 
@@ -15,32 +21,39 @@ bool
 zero_suppression_encode(std::vector<T>& output, const T* input,
                         uintptr_t size)
 {
-    #define BOOST_HISTOGRAM_ZERO_SUPPRESSION_FILL { \
-        if ((size - output.size()) < 2) \
-            return false;                     \
-        output.push_back(0);                  \
-        output.push_back(nzero);              \
-        nzero = 0;                            \
-    }
-
     const T* input_end = input + size;
     T nzero = 0;
     for (; input != input_end; ++input) {
         if (*input != 0) {
-            if (nzero)
-                BOOST_HISTOGRAM_ZERO_SUPPRESSION_FILL
+            if (nzero) {
+				if ((size - output.size()) < 2)
+					return false;
+				output.push_back(0);
+				output.push_back(nzero);
+				nzero = 0;
+            }
             if (output.size() == size)
                 return false;
             output.push_back(*input);
         }
         else {
             ++nzero;
-            if (nzero == 0) // overflowed to zero
-                BOOST_HISTOGRAM_ZERO_SUPPRESSION_FILL
+            if (nzero == 0) { // overflowed to zero
+					if ((size - output.size()) < 2)
+						return false;
+					output.push_back(0);
+					output.push_back(nzero);
+					nzero = 0;
+				}
         }
     }
-    if (nzero)
-        BOOST_HISTOGRAM_ZERO_SUPPRESSION_FILL
+    if (nzero){
+		if ((size - output.size()) < 2)
+			return false;
+		output.push_back(0);
+		output.push_back(nzero);
+		nzero = 0;
+	}
     return true;
 }
 

--- a/include/boost/histogram/histogram.hpp
+++ b/include/boost/histogram/histogram.hpp
@@ -173,7 +173,6 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_VARIANCE,
 private:
   detail::nstore data_;
 
-  friend class serialization::access;
   template <class Archive>
   friend void serialize(Archive& ar, histogram & h, unsigned version);
 };

--- a/include/boost/histogram/histogram.hpp
+++ b/include/boost/histogram/histogram.hpp
@@ -11,8 +11,6 @@
 #include <boost/histogram/basic_histogram.hpp>
 #include <boost/histogram/detail/nstore.hpp>
 #include <boost/preprocessor.hpp>
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/base_object.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/shared_ptr.hpp>

--- a/include/boost/histogram/histogram.hpp
+++ b/include/boost/histogram/histogram.hpp
@@ -12,7 +12,10 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/assert.hpp>
 #include <boost/move/move.hpp>
+#include <boost/range.hpp>
+#include <boost/config.hpp>
 #include <stdexcept>
+#include <iterator>
 
 namespace boost {
 namespace histogram {
@@ -64,11 +67,11 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_CTOR, nil
   }
 
   // C-style call
-  inline
-  void fill_c(unsigned n, const double* v)
+  template<typename Iterator>
+  inline void fill(boost::iterator_range<Iterator> range)
   {
-    BOOST_ASSERT_MSG(n == dim(), "wrong number of arguments");
-    const size_type k = pos(v);
+	BOOST_ASSERT_MSG(range.size() == dim(), "wrong number of arguments");
+    const size_type k = pos(range);
     if (k != uintmax_t(-1))
       data_.increase(k);
   }
@@ -78,18 +81,18 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_CTOR, nil
   void fill( BOOST_PP_ENUM_PARAMS_Z(z, n, double x) )        \
   {                                                          \
     const double buffer[n] = { BOOST_PP_ENUM_PARAMS(n, x) }; \
-    fill_c(n, buffer); /* size is checked here */              \
+    fill(boost::make_iterator_range(boost::begin(buffer), boost::end(buffer)));\
   }
 
 // generates fill functions taking 1 to AXIS_LIMT arguments
 BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_FILL, nil)  
 
-  // C-style call
-  inline
-  void wfill_c(unsigned n, const double* v, double w)
+  // Iterator-style call
+  template<typename Iterator>
+  inline void wfill(boost::iterator_range<Iterator> range, double w)
   {
-    BOOST_ASSERT_MSG(n == dim(), "wrong number of arguments");
-    const size_type k = pos(v);
+    BOOST_ASSERT_MSG(range.size() == dim(), "wrong number of arguments");
+    const size_type k = pos(range);
     if (k != uintmax_t(-1))
       data_.increase(k, w);
   }
@@ -99,7 +102,7 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_FILL, nil
   void wfill( BOOST_PP_ENUM_PARAMS_Z(z, n, double x), double w ) \
   {                                                              \
     const double buffer[n] = { BOOST_PP_ENUM_PARAMS(n, x) };     \
-    wfill_c(n, buffer, w); /* size is checked here */              \
+    wfill(boost::make_iterator_range(boost::begin(buffer), boost::end(buffer)), w); \
   }
 
 // generates wfill functions taking 1 to AXIS_LIMT arguments

--- a/include/boost/histogram/histogram.hpp
+++ b/include/boost/histogram/histogram.hpp
@@ -174,6 +174,7 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_VARIANCE,
     return *this;
   }
 
+  const void* buffer() const {data_.buffer();};
 private:
   detail::nstore data_;
 

--- a/include/boost/histogram/histogram.hpp
+++ b/include/boost/histogram/histogram.hpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef _BOOST_HISTOGRAM_HISTOGRAM_HPP_
 #define _BOOST_HISTOGRAM_HISTOGRAM_HPP_
 
@@ -171,16 +177,10 @@ private:
 
   friend class serialization::access;
   template <class Archive>
-  void serialize(Archive& ar, unsigned version)
-  {
-    ar & serialization::base_object<basic_histogram>(*this);
-    ar & data_;
-  }
-
-  friend class histogram_access;
+  friend void serialize(Archive& ar, histogram & h, unsigned version);
 };
 
-histogram operator+(const histogram& a, const histogram& b) {
+inline histogram operator+(const histogram& a, const histogram& b) {
   histogram result(a);
   return result += b;
 }

--- a/include/boost/histogram/histogram.hpp
+++ b/include/boost/histogram/histogram.hpp
@@ -174,7 +174,7 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_VARIANCE,
     return *this;
   }
 
-  const void* buffer() const {data_.buffer();};
+  const void* buffer() const {return data_.buffer();};
 private:
   detail::nstore data_;
 

--- a/include/boost/histogram/histogram.hpp
+++ b/include/boost/histogram/histogram.hpp
@@ -115,13 +115,12 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_FILL, nil
 BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_WFILL, nil)  
 
   // C-style call
-  inline
-  double value_c(unsigned n, const int* idx)
-    const
+  template<typename Iterator>
+  inline double value(boost::iterator_range<Iterator> range) const
   {
-    if (n != dim())
+    if (range.size() != dim())
     	throw std::range_error("wrong number of arguments");
-    return data_.value(linearize(idx));
+    return data_.value(linearize(range));
   }
 
 #define BOOST_HISTOGRAM_VALUE(z, n, unused)                 \
@@ -130,20 +129,20 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_WFILL, ni
     const                                                   \
   {                                                         \
     const int idx[n] = { BOOST_PP_ENUM_PARAMS_Z(z, n, i) }; \
-    return value_c(n, idx); /* size is checked here */        \
+    return value(boost::make_iterator_range(                \
+						boost::begin(idx), boost::end(idx)  \
+			 	 	 	 )); /* size is checked here */      \
   }
 
 // generates value functions taking 1 to AXIS_LIMT arguments
 BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_VALUE, nil)  
 
-  // C-style call
-  inline
-  double variance_c(unsigned n, const int* idx)
-    const
+  template<typename Iterator>
+  inline double variance(boost::iterator_range<Iterator> range) const
   {
-    if (n != dim())
+    if (range.size() != dim())
     	throw std::runtime_error("wrong number of arguments");
-    return data_.variance(linearize(idx));
+    return data_.variance(linearize(range));
   }
 
 #define BOOST_HISTOGRAM_VARIANCE(z, n, unused)              \
@@ -152,7 +151,9 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_HISTOGRAM_AXIS_LIMIT, BOOST_HISTOGRAM_VALUE, ni
     const                                                   \
   {                                                         \
     const int idx[n] = { BOOST_PP_ENUM_PARAMS_Z(z, n, i) }; \
-    return variance_c(n, idx); /* size is checked here */     \
+    return variance(boost::make_iterator_range(             \
+						boost::begin(idx), boost::end(idx)  \
+						 )); /* size is checked here */     \
   }
 
 // generates variance functions taking 1 to AXIS_LIMT arguments

--- a/include/boost/histogram/serialization.hpp
+++ b/include/boost/histogram/serialization.hpp
@@ -1,0 +1,168 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_HISTOGRAM_SERIALIZATION_HPP_
+#define BOOST_HISTOGRAM_SERIALIZATION_HPP_
+
+#include <boost/histogram/histogram.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/variant.hpp>
+#include <boost/serialization/vector.hpp>
+
+namespace boost {
+namespace histogram {
+
+namespace detail {
+//nstore
+template<class T, class Archive>
+inline void serialize_save_impl(Archive & ar, const nstore & store, unsigned version)
+{
+    std::vector<T> buf;
+    if (zero_suppression_encode<T>(buf, static_cast<T*>(store.buffer_), store.size_)) {
+      bool is_zero_suppressed = true;
+      ar & is_zero_suppressed;
+      ar & buf;
+    } else {
+      bool is_zero_suppressed = false;
+      ar & is_zero_suppressed;
+      ar & serialization::make_array(static_cast<T*>(store.buffer_), store.size_);
+    }
+}
+
+template<class T, class Archive>
+inline void serialize_load_impl(Archive & ar, nstore & store,
+                         bool is_zero_suppressed, unsigned version)
+{
+	  if (is_zero_suppressed) {
+		std::vector<T> buf;
+		ar & buf;
+		zero_suppression_decode<T>(static_cast<T*>(store.buffer_), store.size_, buf);
+	  } else {
+		ar & serialization::make_array(static_cast<T*>(store.buffer_), store.size_);
+	  }
+}
+
+template <class Archive>
+inline void serialize(Archive& ar, nstore & store, unsigned version)
+{
+  const nstore::size_type s = store.size_;
+  const unsigned d = store.depth_;
+  ar & store.size_;
+  ar & store.depth_;
+  if (s != store.size_ || d != store.depth_) {
+    // realloc is safe if buffer_ is null
+	  store.buffer_ = std::realloc(store.buffer_, store.size_ * store.depth_);
+  }
+  if (store.buffer_ == 0 && store.size_ > 0)
+    throw std::bad_alloc();
+
+  if (Archive::is_saving::value) {
+    switch (store.depth_) {
+    case nstore::d1: serialize_save_impl<uint8_t> (ar, store, version); break;
+    case nstore::d2: serialize_save_impl<uint16_t>(ar, store, version); break;
+    case nstore::d4: serialize_save_impl<uint32_t>(ar, store, version); break;
+    case nstore::d8: serialize_save_impl<uint64_t>(ar, store, version); break;
+    case nstore::dw: serialize_save_impl<wtype>   (ar, store, version); break;
+    }
+  }
+
+  if (Archive::is_loading::value) {
+    bool is_zero_suppressed = false;
+    ar & is_zero_suppressed;
+    switch (store.depth_) {
+    case nstore::d1 : serialize_load_impl<uint8_t> (ar, store, is_zero_suppressed, version); break;
+    case nstore::d2 : serialize_load_impl<uint16_t>(ar, store, is_zero_suppressed, version); break;
+    case nstore::d4 : serialize_load_impl<uint32_t>(ar, store, is_zero_suppressed, version); break;
+    case nstore::d8 : serialize_load_impl<uint64_t>(ar, store, is_zero_suppressed, version); break;
+    case nstore::dw : serialize_load_impl<wtype>   (ar, store, is_zero_suppressed, version); break;
+    }
+  }
+}
+
+template <class Archive>
+inline void serialize(Archive& ar, wtype & wt, unsigned version)
+{
+	ar & wt.w; ar & wt.w2;
+}
+
+
+}
+
+template <class Archive>
+inline void serialize(Archive& ar, axis_base & base, unsigned version)
+{
+  using namespace serialization;
+  ar & base.size_;
+  ar & base.label_;
+}
+
+template <class Archive>
+inline void serialize(Archive& ar, regular_axis & axis ,unsigned version)
+{
+  using namespace serialization;
+  ar & boost::serialization::base_object<axis_base>(axis);
+  ar & axis.min_;
+  ar & axis.range_;
+}
+
+template <class Archive>
+inline void serialize(Archive& ar, polar_axis & axis, unsigned version)
+{
+  using namespace serialization;
+  ar & boost::serialization::base_object<axis_base>(axis);
+  ar & axis.start_;
+}
+
+template <class Archive>
+inline void serialize(Archive& ar, variable_axis & axis, unsigned version)
+{
+  ar & boost::serialization::base_object<axis_base>(axis);
+  if (Archive::is_loading::value)
+	  axis.x_.reset(new double[axis.bins() + 1]);
+  ar & serialization::make_array(axis.x_.get(), axis.bins() + 1);
+}
+
+
+template <class Archive>
+inline void serialize(Archive& ar, category_axis & axis, unsigned version)
+{
+  using namespace serialization;
+  ar & axis.categories_;
+}
+
+template <class Archive>
+inline void serialize(Archive& ar, integer_axis & axis, unsigned version)
+{
+  using namespace serialization;
+  ar & boost::serialization::base_object<axis_base>(axis);
+  ar & axis.min_;
+}
+
+template <class Archive>
+inline void serialize(Archive& ar, basic_histogram & h, unsigned version)
+{
+  using namespace serialization;
+  unsigned size = h.axes_.size();
+  ar & size;
+  if (Archive::is_loading::value)
+    h.axes_.resize(size);
+  ar & serialization::make_array(&h.axes_[0], size);
+}
+
+
+template <class Archive>
+inline void serialize(Archive& ar, histogram & h, unsigned version)
+{
+  ar & serialization::base_object<basic_histogram>(h);
+  ar & h.data_;
+}
+
+
+}
+}
+
+#endif

--- a/include/boost/histogram/visitors.hpp
+++ b/include/boost/histogram/visitors.hpp
@@ -34,7 +34,7 @@ namespace visitor {
     template <typename A>
     int operator()(const A& a) const { return a.index(x); }
 
-    int operator()(const category_axis& a) const { return int(x + 0.5); }
+    int operator()(const category_axis& a) const { return static_cast<int>(x + 0.5); }
   };
 
   struct cmp : public static_visitor<bool>

--- a/include/boost/histogram/visitors.hpp
+++ b/include/boost/histogram/visitors.hpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef _BOOST_HISTOGARM_VISITORS_HPP_
 #define _BOOST_HISTOGARM_VISITORS_HPP_
 

--- a/src/axis.cpp
+++ b/src/axis.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/axis.hpp>
 #include <limits>
 #include <sstream>

--- a/src/basic_histogram.cpp
+++ b/src/basic_histogram.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/basic_histogram.hpp>
 #include <boost/histogram/axis.hpp>
 #include <stdexcept>

--- a/src/histogram.cpp
+++ b/src/histogram.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/histogram.hpp>
 #include <ostream>
 

--- a/src/nstore.cpp
+++ b/src/nstore.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/detail/nstore.hpp>
 #include <boost/mpl/map.hpp>
 #include <boost/mpl/int.hpp>

--- a/src/nstore.cpp
+++ b/src/nstore.cpp
@@ -44,7 +44,7 @@ nstore::operator+=(const nstore& o)
     size_type i = size_;
     while (i--) {
       const uint64_t oi = o.ivalue(i);
-      switch (int(depth_)) {
+      switch (static_cast<int>(depth_)) {
         #define BOOST_HISTOGRAM_NSTORE_ADD(D, T)            \
         case D: {                                           \
           T& b = ((T*)buffer_)[i];                          \
@@ -107,12 +107,12 @@ nstore::variance(size_type i)
 void*
 nstore::create(void* buffer)
 {
-  void* b = buffer ? std::malloc(size_ * int(depth_)) :
-                     std::calloc(size_, int(depth_));
+  void* b = buffer ? std::malloc(size_ * static_cast<int>(depth_)) :
+                     std::calloc(size_,  static_cast<int>(depth_));
   if (!b)
     throw std::bad_alloc();
   if (buffer)
-    std::memcpy(b, buffer, size_ * int(depth_));
+    std::memcpy(b, buffer, size_ * static_cast<int>(depth_));
   return b;
 }
 
@@ -131,7 +131,7 @@ nstore::grow()
     #define BOOST_HISTOGRAM_NSTORE_GROW(D0, T0, D1, T1) \
     case D0:                                            \
       depth_ = D1;                                      \
-      buffer_ = std::realloc(buffer_, size_ * int(depth_)); \
+      buffer_ = std::realloc(buffer_, size_ * static_cast<int>(depth_)); \
       if (!buffer_) throw std::bad_alloc();             \
       while (i--)                                       \
         ((T1*)buffer_)[i] = ((T0*)buffer_)[i];          \
@@ -151,7 +151,7 @@ nstore::wconvert()
   BOOST_ASSERT(size_ > 0);
   BOOST_ASSERT(depth_ < dw);
   // realloc is safe if buffer_ is null
-  buffer_ = std::realloc(buffer_, size_ * int(dw));
+  buffer_ = std::realloc(buffer_, size_ * static_cast<int>(dw));
   if (!buffer_) throw std::bad_alloc();
   size_type i = size_;
   switch (depth_) {

--- a/src/nstore.cpp
+++ b/src/nstore.cpp
@@ -38,26 +38,17 @@ nstore::operator+=(const nstore& o)
   // now add the content of lhs, grow as needed
   if (depth_ == dw) {
     for (size_type i = 0; i < size_; ++i)
-      ((wtype*)buffer_)[i] += ((wtype*)o.buffer_)[i];
+    	static_cast<wtype*>(buffer_)[i] += static_cast<wtype*>(o.buffer_)[i];
   }
   else {
     size_type i = size_;
     while (i--) {
       const uint64_t oi = o.ivalue(i);
       switch (static_cast<int>(depth_)) {
-        #define BOOST_HISTOGRAM_NSTORE_ADD(D, T)            \
-        case D: {                                           \
-          T& b = ((T*)buffer_)[i];                          \
-          if (T(std::numeric_limits<T>::max() - b) >= oi) { \
-            b += oi;                                        \
-            break;                                          \
-          } else grow(); /* and fall through */             \
-        }
-        BOOST_HISTOGRAM_NSTORE_ADD(d1, uint8_t);
-        BOOST_HISTOGRAM_NSTORE_ADD(d2, uint16_t);
-        BOOST_HISTOGRAM_NSTORE_ADD(d4, uint32_t);
-        BOOST_HISTOGRAM_NSTORE_ADD(d8, uint64_t);
-        #undef BOOST_HISTOGRAM_NSTORE_ADD
+        case d1: if (add_impl_<uint8_t> (i, oi)) break;
+        case d2: if (add_impl_<uint16_t> (i, oi)) break;
+        case d4: if (add_impl_<uint32_t> (i, oi)) break;
+        case d8: if (add_impl_<uint64_t> (i, oi)) break;
         case dw: {
           ((wtype*)buffer_)[i] += wtype(oi);
           break;
@@ -91,14 +82,11 @@ nstore::variance(size_type i)
   const
 {
   switch (depth_) {
-    #define BOOST_HISTOGRAM_NSTORE_VARIANCE(D, T) \
-    case D: return ((T*)buffer_)[i]
-    BOOST_HISTOGRAM_NSTORE_VARIANCE(d1, uint8_t);
-    BOOST_HISTOGRAM_NSTORE_VARIANCE(d2, uint16_t);
-    BOOST_HISTOGRAM_NSTORE_VARIANCE(d4, uint32_t);
-    BOOST_HISTOGRAM_NSTORE_VARIANCE(d8, uint64_t);
-    #undef BOOST_HISTOGRAM_NSTORE_VARIANCE
-    case dw: return ((wtype*)buffer_)[i].w2;
+    case d1: return static_cast<uint8_t *>(buffer_)[i];
+    case d2: return static_cast<uint16_t*>(buffer_)[i];
+    case d4: return static_cast<uint32_t*>(buffer_)[i];
+    case d8: return static_cast<uint64_t*>(buffer_)[i];
+    case dw: return static_cast<wtype*>(buffer_)[i].w2;
   }
   BOOST_ASSERT(!"never arrive here");
   return 0.0;
@@ -126,24 +114,16 @@ void
 nstore::grow()
 {
   BOOST_ASSERT(size_ > 0);
-  size_type i = size_;
   switch (depth_) {
-    #define BOOST_HISTOGRAM_NSTORE_GROW(D0, T0, D1, T1) \
-    case D0:                                            \
-      depth_ = D1;                                      \
-      buffer_ = std::realloc(buffer_, size_ * static_cast<int>(depth_)); \
-      if (!buffer_) throw std::bad_alloc();             \
-      while (i--)                                       \
-        ((T1*)buffer_)[i] = ((T0*)buffer_)[i];          \
-      return
-    BOOST_HISTOGRAM_NSTORE_GROW(d1, uint8_t, d2, uint16_t);
-    BOOST_HISTOGRAM_NSTORE_GROW(d2, uint16_t, d4, uint32_t);
-    BOOST_HISTOGRAM_NSTORE_GROW(d4, uint32_t, d8, uint64_t);
-    BOOST_HISTOGRAM_NSTORE_GROW(d8, uint64_t, dw, wtype);
-    #undef BOOST_HISTOGRAM_NSTORE_GROW
+    case d1: grow_impl<uint8_t,  uint16_t>(); break;
+    case d2: grow_impl<uint16_t, uint32_t>(); break;
+    case d4: grow_impl<uint32_t, uint64_t>(); break;
+    case d8: grow_impl<uint64_t, wtype>();    break;
     case dw: BOOST_ASSERT(!"never arrive here");
   }
 }
+
+
 
 void
 nstore::wconvert()
@@ -153,18 +133,11 @@ nstore::wconvert()
   // realloc is safe if buffer_ is null
   buffer_ = std::realloc(buffer_, size_ * static_cast<int>(dw));
   if (!buffer_) throw std::bad_alloc();
-  size_type i = size_;
   switch (depth_) {
-    #define BOOST_HISTOGRAM_NSTORE_CONVERT(D, T) \
-    case D:                                      \
-    while (i--)                                  \
-      ((wtype*)buffer_)[i] = ((T*)buffer_)[i];   \
-    break
-    BOOST_HISTOGRAM_NSTORE_CONVERT(d1, uint8_t);
-    BOOST_HISTOGRAM_NSTORE_CONVERT(d2, uint16_t);
-    BOOST_HISTOGRAM_NSTORE_CONVERT(d4, uint32_t);
-    BOOST_HISTOGRAM_NSTORE_CONVERT(d8, uint64_t);
-    #undef BOOST_HISTOGRAM_NSTORE_CONVERT
+    case d1: wconvert_impl<uint8_t> (); break;
+    case d2: wconvert_impl<uint16_t>(); break;
+    case d4: wconvert_impl<uint32_t>(); break;
+    case d8: wconvert_impl<uint64_t>(); break;
     case dw: BOOST_ASSERT(!"never arrive here");
   }
   depth_ = dw;
@@ -175,13 +148,10 @@ nstore::ivalue(size_type i)
   const
 {
   switch (depth_) {
-    #define BOOST_HISTOGRAM_NSTORE_IVALUE(D, T) \
-    case D: return ((T*)buffer_)[i]
-    BOOST_HISTOGRAM_NSTORE_IVALUE(d1, uint8_t);
-    BOOST_HISTOGRAM_NSTORE_IVALUE(d2, uint16_t);
-    BOOST_HISTOGRAM_NSTORE_IVALUE(d4, uint32_t);
-    BOOST_HISTOGRAM_NSTORE_IVALUE(d8, uint64_t);
-    #undef BOOST_HISTOGRAM_NSTORE_IVALUE
+    case d1: return static_cast<uint8_t *>(buffer_)[i];
+    case d2: return static_cast<uint16_t*>(buffer_)[i];
+    case d4: return static_cast<uint32_t*>(buffer_)[i];
+    case d8: return static_cast<uint64_t*>(buffer_)[i];
     case dw: BOOST_ASSERT(!"never arrive here");
   }
   return 0;

--- a/src/python/axis.cpp
+++ b/src/python/axis.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/axis.hpp>
 #include <boost/python.hpp>
 #include <boost/python/raw_function.hpp>

--- a/src/python/basic_histogram.cpp
+++ b/src/python/basic_histogram.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/axis.hpp>
 #include <boost/histogram/basic_histogram.hpp>
 #include <boost/python.hpp>

--- a/src/python/histogram.cpp
+++ b/src/python/histogram.cpp
@@ -155,10 +155,11 @@ histogram_fill(python::tuple args, python::dict kwargs) {
         v[i] = extract<double>(args[1 + i]);
 
     if (ow.is_none()) {
-        self.fill_c(self.dim(), v);
+        self.fill(boost::make_iterator_range(v, v+self.dim()));
+
     } else {
         const double w = extract<double>(ow);
-        self.wfill_c(self.dim(), v, w);
+        self.wfill(boost::make_iterator_range(v, v+self.dim()), w);
     }
 
     return object();
@@ -217,14 +218,14 @@ public:
         python::list shape;
         for (unsigned i = 0; i < self.dim(); ++i)
             shape.append(self.shape(i));
-        if (self.data_.depth() == sizeof(detail::wtype)) {
+        if (self.depth() == sizeof(detail::wtype)) {
             shape.append(2);
             d["typestr"] = python::str("<f") + python::str(sizeof(double));
         } else {
-            d["typestr"] = python::str("<u") + python::str(self.data_.depth());
+            d["typestr"] = python::str("<u") + python::str(self.depth());
         }
         d["shape"] = python::tuple(shape);
-        d["data"] = python::make_tuple((long long)(self.data_.buffer()), false);
+        d["data"] = python::make_tuple(reinterpret_cast<boost::uintptr_t>(self.buffer()), false);
         return d;
     }
 };

--- a/src/python/histogram.cpp
+++ b/src/python/histogram.cpp
@@ -184,7 +184,7 @@ histogram_value(python::tuple args, python::dict kwargs) {
     for (unsigned i = 0; i < self.dim(); ++i)
         idx[i] = extract<int>(args[1 + i]);
 
-    return object(self.value_c(self.dim(), idx));
+    return object(self.value(boost::make_iterator_range(idx, idx + self.dim())));
 }
 
 python::object
@@ -206,7 +206,7 @@ histogram_variance(python::tuple args, python::dict kwargs) {
     for (unsigned i = 0; i < self.dim(); ++i)
         idx[i] = extract<int>(args[1 + i]);
 
-    return object(self.variance_c(self.dim(), idx));
+    return object(self.variance(boost::make_iterator_range(idx, idx + self.dim())));
 }
 
 class histogram_access {

--- a/src/python/histogram.cpp
+++ b/src/python/histogram.cpp
@@ -74,8 +74,8 @@ histogram_fill(python::tuple args, python::dict kwargs) {
     if (nargs == 2) {
         object o = args[1];
         if (PySequence_Check(o.ptr())) {
-            PyArrayObject* a = (PyArrayObject*)
-                PyArray_FROM_OTF(o.ptr(), NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+            PyArrayObject* a = static_caste<PyArrayObject*>
+                (PyArray_FROM_OTF(o.ptr(), NPY_DOUBLE, NPY_ARRAY_IN_ARRAY));
             if (!a) {
                 PyErr_SetString(PyExc_ValueError, "could not convert sequence into array");
                 throw_error_already_set();
@@ -103,8 +103,8 @@ histogram_fill(python::tuple args, python::dict kwargs) {
 
             if (!ow.is_none()) {
                 if (PySequence_Check(ow.ptr())) {
-                    PyArrayObject* aw = (PyArrayObject*)
-                        PyArray_FROM_OTF(ow.ptr(), NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+                    PyArrayObject* aw = static_cast<PyArrayObject*>
+                        (PyArray_FROM_OTF(ow.ptr(), NPY_DOUBLE, NPY_ARRAY_IN_ARRAY));
                     if (!aw) {
                         PyErr_SetString(PyExc_ValueError, "could not convert sequence into array");
                         throw_error_already_set();                        
@@ -121,9 +121,9 @@ histogram_fill(python::tuple args, python::dict kwargs) {
                     }
 
                     for (unsigned i = 0; i < dims[0]; ++i) {
-                        double* v = (double*)PyArray_GETPTR1(a, i);
-                        double* w = (double*)PyArray_GETPTR1(aw, i);
-                        self.wfill_c(self.dim(), v, *w);
+                        double* v = static_cast<double*>(PyArray_GETPTR1(a, i) );
+                        double* w = static_cast<double*>(PyArray_GETPTR1(aw, i));
+                        self.wfill(boost::make_iterator_range(v, v+self.dim()), *w);
                     }
 
                     Py_DECREF(aw);
@@ -133,8 +133,8 @@ histogram_fill(python::tuple args, python::dict kwargs) {
                 }
             } else {
                 for (unsigned i = 0; i < dims[0]; ++i) {
-                    double* v = (double*)PyArray_GETPTR1(a, i);
-                    self.fill_c(self.dim(), v);
+                    double* v = static_cast<double*>(PyArray_GETPTR1(a, i));
+                    self.fill(boost::make_iterator_range(v, v+self.dim()));
                 }
             }
 

--- a/src/python/histogram.cpp
+++ b/src/python/histogram.cpp
@@ -74,7 +74,7 @@ histogram_fill(python::tuple args, python::dict kwargs) {
     if (nargs == 2) {
         object o = args[1];
         if (PySequence_Check(o.ptr())) {
-            PyArrayObject* a = static_caste<PyArrayObject*>
+            PyArrayObject* a = reinterpret_cast<PyArrayObject*>
                 (PyArray_FROM_OTF(o.ptr(), NPY_DOUBLE, NPY_ARRAY_IN_ARRAY));
             if (!a) {
                 PyErr_SetString(PyExc_ValueError, "could not convert sequence into array");
@@ -103,7 +103,7 @@ histogram_fill(python::tuple args, python::dict kwargs) {
 
             if (!ow.is_none()) {
                 if (PySequence_Check(ow.ptr())) {
-                    PyArrayObject* aw = static_cast<PyArrayObject*>
+                    PyArrayObject* aw = reinterpret_cast<PyArrayObject*>
                         (PyArray_FROM_OTF(ow.ptr(), NPY_DOUBLE, NPY_ARRAY_IN_ARRAY));
                     if (!aw) {
                         PyErr_SetString(PyExc_ValueError, "could not convert sequence into array");
@@ -121,8 +121,8 @@ histogram_fill(python::tuple args, python::dict kwargs) {
                     }
 
                     for (unsigned i = 0; i < dims[0]; ++i) {
-                        double* v = static_cast<double*>(PyArray_GETPTR1(a, i) );
-                        double* w = static_cast<double*>(PyArray_GETPTR1(aw, i));
+                        double* v = reinterpret_cast<double*>(PyArray_GETPTR1(a, i) );
+                        double* w = reinterpret_cast<double*>(PyArray_GETPTR1(aw, i));
                         self.wfill(boost::make_iterator_range(v, v+self.dim()), *w);
                     }
 
@@ -133,7 +133,7 @@ histogram_fill(python::tuple args, python::dict kwargs) {
                 }
             } else {
                 for (unsigned i = 0; i < dims[0]; ++i) {
-                    double* v = static_cast<double*>(PyArray_GETPTR1(a, i));
+                    double* v = reinterpret_cast<double*>(PyArray_GETPTR1(a, i));
                     self.fill(boost::make_iterator_range(v, v+self.dim()));
                 }
             }

--- a/src/python/histogram.cpp
+++ b/src/python/histogram.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include "serialization_suite.hpp"
 #include <boost/histogram/axis.hpp>
 #include <boost/histogram/histogram.hpp>

--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/python/module.hpp>
 #ifdef HAVE_NUMPY
 # define PY_ARRAY_UNIQUE_SYMBOL boost_histogram_ARRAY_API

--- a/src/python/serialization_suite.hpp
+++ b/src/python/serialization_suite.hpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #ifndef _BOOST_PYTHON_SERIALIZATION_SUITE_HPP_
 #define _BOOST_PYTHON_SERIALIZATION_SUITE_HPP_
 

--- a/src/zero_suppression.cpp
+++ b/src/zero_suppression.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/detail/zero_suppression.hpp>
 
 namespace boost {
@@ -9,20 +15,18 @@ bool
 zero_suppression_encode(std::vector<wtype>& output, const wtype* input,
                         uintptr_t size)
 {
-    #define BOOST_HISTOGRAM_ZERO_SUPPRESSION_FILL { \
-        if ((size - output.size()) < 2)       \
-            return false;                     \
-        output.push_back(0);                  \
-        output.push_back(nzero);              \
-        nzero = 0;                            \
-    }
 
     const wtype* input_end = input + size;
     uint32_t nzero = 0;
     for (; input != input_end; ++input) {
         if (*input != 0) {
-            if (nzero)
-                BOOST_HISTOGRAM_ZERO_SUPPRESSION_FILL
+            if (nzero) {
+                if ((size - output.size()) < 2)
+                    return false;
+                output.push_back(0);
+                output.push_back(nzero);
+                nzero = 0;
+            }
             if (output.size() == size)
                 return false;
             output.push_back(*input);
@@ -30,11 +34,22 @@ zero_suppression_encode(std::vector<wtype>& output, const wtype* input,
         else {
             ++nzero;
             if (nzero == 0) // overflowed to zero
-                BOOST_HISTOGRAM_ZERO_SUPPRESSION_FILL
+            {
+				if ((size - output.size()) < 2)
+					return false;
+				output.push_back(0);
+				output.push_back(nzero);
+				nzero = 0;
+			}
         }
     }
-    if (nzero)
-        BOOST_HISTOGRAM_ZERO_SUPPRESSION_FILL
+    if (nzero){
+            if ((size - output.size()) < 2)
+                return false;
+            output.push_back(0);
+            output.push_back(nzero);
+            nzero = 0;
+        }
     return true;
 }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,4 +1,4 @@
-# Copyright David Abrahams 2006. Distributed under the Boost
+# Copyright Klemens David Morgenstern 2016. Distributed under the Boost
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -19,6 +19,7 @@ import os ;
 
 test-suite ts : 
     [ compile check/sizeof.cpp ]
+    [ compile serialization.cpp ]
     #[ compile check/speed_vs_root.cpp ] //not in yet, cause it needs an external library
     [ run axis_test.cpp             /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]
     [ run histogram_test.cpp        /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,0 +1,29 @@
+# Copyright David Abrahams 2006. Distributed under the Boost
+# Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+
+#use-project /boost/histogram : ../build ;
+
+project 
+  : requirements
+    <target-os>windows:<define>WIN32_LEAN_AND_MEAN
+    <target-os>linux:<linkflags>-lpthread
+  ;
+
+  
+import testing ;
+import python ;
+import os ;
+
+test-suite ts : 
+    [ compile check/sizeof.cpp ]
+    #[ compile check/speed_vs_root.cpp ] //not in yet, cause it needs an external library
+    [ run axis_test.cpp             /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]
+    [ run histogram_test.cpp        /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]
+    [ run nstore_test.cpp           /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]
+    [ run zero_suppression_test.cpp /boost//histogram /boost//test_exec_monitor : <define>BOOST_TEST_DYN_LINK=1 ]
+    ;
+  
+ 

--- a/test/axis_test.cpp
+++ b/test/axis_test.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/axis.hpp>
 #define BOOST_TEST_MODULE axis_test
 #include <boost/test/unit_test.hpp>

--- a/test/check/sizeof.cpp
+++ b/test/check/sizeof.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <cstdio>
 #include <boost/preprocessor.hpp>
 #include <boost/histogram/axis.hpp>

--- a/test/check/speed_vs_root.cpp
+++ b/test/check/speed_vs_root.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/histogram.hpp>
 #include <boost/histogram/axis.hpp>
 #include <boost/random.hpp>

--- a/test/histogram_test.cpp
+++ b/test/histogram_test.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/histogram.hpp>
 #define BOOST_TEST_MODULE histogram_test
 #include <boost/test/unit_test.hpp>

--- a/test/nstore_test.cpp
+++ b/test/nstore_test.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/detail/nstore.hpp>
 #include <boost/histogram/detail/wtype.hpp>
 #define BOOST_TEST_MODULE nstore_test

--- a/test/serialization.cpp
+++ b/test/serialization.cpp
@@ -1,0 +1,23 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/serialization/serialization.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/histogram.hpp>
+#include <fstream>
+
+void serialize()
+{
+	std::fstream fs;
+	boost::archive::binary_iarchive bi(fs);
+	boost::archive::binary_oarchive bo(fs);
+
+	boost::histogram::histogram hs;
+
+	bi & hs;
+	bo & hs;
+}

--- a/test/zero_suppression_test.cpp
+++ b/test/zero_suppression_test.cpp
@@ -1,3 +1,9 @@
+// Copyright 2015-2016 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/histogram/detail/zero_suppression.hpp>
 #define BOOST_TEST_MODULE zero_suppression_test
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
Hi Hans,

I added comments with copyright and moved the serialization to a custom header and added a compile test for the latter (b2 only). I also removed all unneeded macros (was quite unreadable with the locally declared ones).

It now has a new header (boost/histogram/serialization) with the serialization defs.
Also boost/histogram.hpp was added for convience, i..e it include histogram.hpp and serialization.hpp.

Lastly, I changed fill_c and wfill_c to fill(boost::iterator_range). Passing to iterators would've been an invalid ambiguity (when passing int), so now it takes a range. Should be fine, since it's already a boost library.

LG,

Klemens