### PR TITLE
make fails to find sync_code.py with just "../doc".

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -102,7 +102,7 @@ else()
 endif()
 
 # sync examples in documentation with example folder
-add_custom_target(sync_examples ALL COMMAND python ../doc/sync_code.py)
+add_custom_target(sync_examples ALL COMMAND python ${PROJECT_SOURCE_DIR}/../doc/sync_code.py)
 
 # checks
 if(BUILD_CHECKS)


### PR DESCRIPTION
Fixes
```
python: can't open file '../doc/sync_code.py': [Errno 2] No such file or directory
```
when running `make` after `cmake -DBOOST_ROOT=/Users/axel/build/boost/inst/ ../src/build/`
