### PR TITLE
Fixes for MSVC

### DIFF
--- a/include/boost/histogram/detail/cat.hpp
+++ b/include/boost/histogram/detail/cat.hpp
@@ -9,6 +9,10 @@
 
 #include <sstream>
 
+#ifdef _MSC_VER
+#define __attribute__(A) // ignore GCC extension
+#endif
+
 namespace boost {
 namespace histogram {
 namespace detail {

--- a/include/boost/histogram/detail/utility.hpp
+++ b/include/boost/histogram/detail/utility.hpp
@@ -40,7 +40,9 @@ inline void lin(std::size_t &out, std::size_t &stride, const Axis &a,
   stride *= (j >= -uoflow) & (j < (a.size() + uoflow));
   j += (j < 0) * (a.size() + 2); // wrap around if in < 0
   out += j * stride;
+#ifndef _MSC_VER
 #pragma GCC diagnostic ignored "-Wstrict-overflow"
+#endif
   stride *= a.shape();
 }
 
@@ -53,7 +55,9 @@ inline void xlin(std::size_t &out, std::size_t &stride, const Axis &a,
   // j is guaranteed to be in range [-1, bins]
   j += (j < 0) * (a.size() + 2); // wrap around if j < 0
   out += j * stride;
+#ifndef _MSC_VER
 #pragma GCC diagnostic ignored "-Wstrict-overflow"
+#endif
   stride *= (j < a.shape()) * a.shape(); // stride == 0 indicates out-of-range
 }
 

--- a/include/boost/histogram/histogram_fwd.hpp
+++ b/include/boost/histogram/histogram_fwd.hpp
@@ -36,11 +36,13 @@ template <typename IntType = int> class integer;
 template <typename T = int> class category;
 
 using builtins =
-    mpl::vector<axis::regular<>, axis::regular<double, axis::transform::log>,
+    mpl::vector<axis::regular<double, axis::transform::identity>,
+                axis::regular<double, axis::transform::log>,
                 axis::regular<double, axis::transform::sqrt>,
                 axis::regular<double, axis::transform::cos>,
-                axis::regular<double, axis::transform::pow>, axis::circular<>,
-                axis::variable<>, axis::integer<>, axis::category<>,
+                axis::regular<double, axis::transform::pow>,
+                axis::circular<double>, axis::variable<double>,
+                axis::integer<int>, axis::category<int>,
                 axis::category<std::string>>;
 
 template <typename Axes = builtins> class any;

--- a/include/boost/histogram/storage/adaptive_storage.hpp
+++ b/include/boost/histogram/storage/adaptive_storage.hpp
@@ -463,8 +463,8 @@ public:
   // precondition: storages have same size
   adaptive_storage &operator+=(const adaptive_storage &rhs) {
     if (this == &rhs) {
-      for (auto i = 0ul, n = size(); i < n; ++i) {
-        add(i, rhs[i]); // may loose precision
+      for (decltype(size()) i = 0, n = size(); i < n; ++i) {
+        add(i, rhs[i]); // may lose precision
       }
     } else {
       apply_visitor(detail::radd_array_visitor(buffer_), rhs.buffer_);


### PR DESCRIPTION
Here is a first pass at fixing some build issues with MSVC on the develop branch. I am testing with Visual Studio 2017 (19.12.25835) and the v2.0 release has been working nicely. List of issues and comments follows.

**Tests passing:** adaptive_storage_test, array_storage_test, axis_size, detail_test, weight_counter_test
**Tests failing (will not compile):** axis_test, histogram_test

## Ignore GCC Extensions

This addresses MSVC warning [C4068](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4068) (unknown pragma) and undeclared identifier errors.

I added some `#ifdef _MSC_VER` guards to make `__attribute__((unused))` a no-op, and disable GCC diagnostic pragmas that have no MSVC equivalent. This could go the other way around as well - definitions could be added specifically for GCC and clang.

`__attribute__((unused))`  could be replaced with C++11 style `[[gnu::unused]]` and newer versions of MSVC shouldn't have a problem with unknown attributes, but this may be the slightly safer route for older compilers.

## _Temporary_ Fix for Built-in Axis Types

I was getting errors [C2976](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c2976) and [C3203](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c3203) when attempting to compile the `builtins` mpl::vector. Brief listing follows; the same error was reported for the regular, circular, variable, integer and category axis types:

```
histogram_fwd.hpp(39): error C2976: 'boost::histogram::axis::regular': too few template arguments
histogram_fwd.hpp(44): error C3203: 'regular': unspecialized class template can't be used as a template argument for template parameter 'T0', expected a real type
...
```

I'm new to template metaprogramming so not sure whether MSVC is in the wrong here. As a workaround, I explicitly specialized all types. This may mean that the 'any' class loses genericity, but it only had options for built-in types anyway. Would a user-defined axis class that didn't derive from a built-in type work with `any`, for example `axis_base` or `axis_base_uoflow`?

This is temporary because the **axis_test** and **histogram_test** are failing with a long list of error messages that I think are all ultimately related to `any`. I don't see any 'quick fix' at the moment.

## Type Deduction Fix

This addresses MSVC error [C3538](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c3538), output follows:

```
adaptive_storage.hpp(466): error C3538: in a declarator-list 'auto' must always deduce to the same type
adaptive_storage.hpp(466): note: could be 'unsigned long'
adaptive_storage.hpp(466): note: or '::size_t'
```

I just swapped out the `auto` for `decltype(size())`.


