### PR TITLE
Fix include guards without leading underscore

### DIFF
--- a/include/boost/histogram.hpp
+++ b/include/boost/histogram.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef BOOST_HISTOGRAM_HPP_
-#define BOOST_HISTOGRAM_HPP_
+#ifndef BOOST_HISTOGRAM_HPP
+#define BOOST_HISTOGRAM_HPP
 
 #include <boost/histogram/axis/any.hpp>
 #include <boost/histogram/axis/types.hpp>

--- a/include/boost/histogram/arithmetic_operators.hpp
+++ b/include/boost/histogram/arithmetic_operators.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_HISTOGRAM_ARITHMETIC_OPERATORS_HPP_
-#define _BOOST_HISTOGRAM_HISTOGRAM_ARITHMETIC_OPERATORS_HPP_
+#ifndef BOOST_HISTOGRAM_HISTOGRAM_ARITHMETIC_OPERATORS_HPP
+#define BOOST_HISTOGRAM_HISTOGRAM_ARITHMETIC_OPERATORS_HPP
 
 #include <boost/histogram/histogram_fwd.hpp>
 

--- a/include/boost/histogram/axis/any.hpp
+++ b/include/boost/histogram/axis/any.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_AXIS_ANY_HPP_
-#define _BOOST_HISTOGRAM_AXIS_ANY_HPP_
+#ifndef BOOST_HISTOGRAM_AXIS_ANY_HPP
+#define BOOST_HISTOGRAM_AXIS_ANY_HPP
 
 #include <boost/histogram/axis/base.hpp>
 #include <boost/histogram/axis/interval_view.hpp>

--- a/include/boost/histogram/axis/base.hpp
+++ b/include/boost/histogram/axis/base.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_AXIS_BASE_HPP_
-#define _BOOST_HISTOGRAM_AXIS_BASE_HPP_
+#ifndef BOOST_HISTOGRAM_AXIS_BASE_HPP
+#define BOOST_HISTOGRAM_AXIS_BASE_HPP
 
 #include <boost/config.hpp>
 #include <boost/container/string.hpp>

--- a/include/boost/histogram/axis/interval_view.hpp
+++ b/include/boost/histogram/axis/interval_view.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_AXIS_INTERVAL_VIEW_HPP_
-#define _BOOST_HISTOGRAM_AXIS_INTERVAL_VIEW_HPP_
+#ifndef BOOST_HISTOGRAM_AXIS_INTERVAL_VIEW_HPP
+#define BOOST_HISTOGRAM_AXIS_INTERVAL_VIEW_HPP
 
 #include <functional>
 #include <utility>

--- a/include/boost/histogram/axis/iterator.hpp
+++ b/include/boost/histogram/axis/iterator.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_AXIS_ITERATOR_HPP_
-#define _BOOST_HISTOGRAM_AXIS_ITERATOR_HPP_
+#ifndef BOOST_HISTOGRAM_AXIS_ITERATOR_HPP
+#define BOOST_HISTOGRAM_AXIS_ITERATOR_HPP
 
 #include <boost/iterator/iterator_facade.hpp>
 

--- a/include/boost/histogram/axis/ostream_operators.hpp
+++ b/include/boost/histogram/axis/ostream_operators.hpp
@@ -6,8 +6,8 @@
 //
 // String representations here evaluate correctly in Python.
 
-#ifndef _BOOST_HISTOGRAM_AXIS_OSTREAM_OPERATORS_HPP_
-#define _BOOST_HISTOGRAM_AXIS_OSTREAM_OPERATORS_HPP_
+#ifndef BOOST_HISTOGRAM_AXIS_OSTREAM_OPERATORS_HPP
+#define BOOST_HISTOGRAM_AXIS_OSTREAM_OPERATORS_HPP
 
 #include <boost/histogram/axis/interval_view.hpp>
 #include <boost/histogram/axis/types.hpp>

--- a/include/boost/histogram/axis/types.hpp
+++ b/include/boost/histogram/axis/types.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_AXIS_TYPES_HPP_
-#define _BOOST_HISTOGRAM_AXIS_TYPES_HPP_
+#ifndef BOOST_HISTOGRAM_AXIS_TYPES_HPP
+#define BOOST_HISTOGRAM_AXIS_TYPES_HPP
 
 #include <algorithm>
 #include <boost/histogram/axis/base.hpp>

--- a/include/boost/histogram/axis/value_view.hpp
+++ b/include/boost/histogram/axis/value_view.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_AXIS_VALUE_VIEW_HPP_
-#define _BOOST_HISTOGRAM_AXIS_VALUE_VIEW_HPP_
+#ifndef BOOST_HISTOGRAM_AXIS_VALUE_VIEW_HPP
+#define BOOST_HISTOGRAM_AXIS_VALUE_VIEW_HPP
 
 #include <functional>
 #include <utility>

--- a/include/boost/histogram/detail/axes.hpp
+++ b/include/boost/histogram/detail/axes.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_DETAIL_AXES_HPP_
-#define _BOOST_HISTOGRAM_DETAIL_AXES_HPP_
+#ifndef BOOST_HISTOGRAM_DETAIL_AXES_HPP
+#define BOOST_HISTOGRAM_DETAIL_AXES_HPP
 
 #include <algorithm>
 #include <boost/assert.hpp>

--- a/include/boost/histogram/detail/buffer.hpp
+++ b/include/boost/histogram/detail/buffer.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_DETAIL_BUFFER_HPP_
-#define _BOOST_HISTOGRAM_DETAIL_BUFFER_HPP_
+#ifndef BOOST_HISTOGRAM_DETAIL_BUFFER_HPP
+#define BOOST_HISTOGRAM_DETAIL_BUFFER_HPP
 
 #include <boost/histogram/detail/meta.hpp>
 #include <cstddef>

--- a/include/boost/histogram/detail/cat.hpp
+++ b/include/boost/histogram/detail/cat.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_DETAIL_CAT_HPP_
-#define _BOOST_HISTOGRAM_DETAIL_CAT_HPP_
+#ifndef BOOST_HISTOGRAM_DETAIL_CAT_HPP
+#define BOOST_HISTOGRAM_DETAIL_CAT_HPP
 
 #include <boost/config.hpp>
 #include <sstream>

--- a/include/boost/histogram/detail/index_cache.hpp
+++ b/include/boost/histogram/detail/index_cache.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_DETAIL_INDEX_CACHE_HPP_
-#define _BOOST_HISTOGRAM_DETAIL_INDEX_CACHE_HPP_
+#ifndef BOOST_HISTOGRAM_DETAIL_INDEX_CACHE_HPP
+#define BOOST_HISTOGRAM_DETAIL_INDEX_CACHE_HPP
 
 #include <cstddef>
 #include <memory>

--- a/include/boost/histogram/detail/index_mapper.hpp
+++ b/include/boost/histogram/detail/index_mapper.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_DETAIL_INDEX_MAPPER_HPP_
-#define _BOOST_HISTOGRAM_DETAIL_INDEX_MAPPER_HPP_
+#ifndef BOOST_HISTOGRAM_DETAIL_INDEX_MAPPER_HPP
+#define BOOST_HISTOGRAM_DETAIL_INDEX_MAPPER_HPP
 
 #include <algorithm>
 #include <cstddef>

--- a/include/boost/histogram/detail/meta.hpp
+++ b/include/boost/histogram/detail/meta.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_DETAIL_META_HPP_
-#define _BOOST_HISTOGRAM_DETAIL_META_HPP_
+#ifndef BOOST_HISTOGRAM_DETAIL_META_HPP
+#define BOOST_HISTOGRAM_DETAIL_META_HPP
 
 #include <boost/callable_traits/args.hpp>
 #include <boost/mp11.hpp>

--- a/include/boost/histogram/histogram.hpp
+++ b/include/boost/histogram/histogram.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_HISTOGRAM_HPP_
-#define _BOOST_HISTOGRAM_HISTOGRAM_HPP_
+#ifndef BOOST_HISTOGRAM_HISTOGRAM_HPP
+#define BOOST_HISTOGRAM_HISTOGRAM_HPP
 
 #include <algorithm>
 #include <boost/assert.hpp>

--- a/include/boost/histogram/histogram_fwd.hpp
+++ b/include/boost/histogram/histogram_fwd.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_HISTOGRAM_FWD_HPP_
-#define _BOOST_HISTOGRAM_HISTOGRAM_FWD_HPP_
+#ifndef BOOST_HISTOGRAM_HISTOGRAM_FWD_HPP
+#define BOOST_HISTOGRAM_HISTOGRAM_FWD_HPP
 
 #include <memory> // for std::allocator
 #include <vector>

--- a/include/boost/histogram/iterator.hpp
+++ b/include/boost/histogram/iterator.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_VALUE_ITERATOR_HPP_
-#define _BOOST_HISTOGRAM_VALUE_ITERATOR_HPP_
+#ifndef BOOST_HISTOGRAM_VALUE_ITERATOR_HPP
+#define BOOST_HISTOGRAM_VALUE_ITERATOR_HPP
 
 #include <boost/histogram/detail/index_cache.hpp>
 #include <boost/histogram/histogram_fwd.hpp>

--- a/include/boost/histogram/literals.hpp
+++ b/include/boost/histogram/literals.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_LITERALS_HPP_
-#define _BOOST_HISTOGRAM_LITERALS_HPP_
+#ifndef BOOST_HISTOGRAM_LITERALS_HPP
+#define BOOST_HISTOGRAM_LITERALS_HPP
 
 #include <boost/mp11.hpp>
 #include <cstddef>

--- a/include/boost/histogram/ostream_operators.hpp
+++ b/include/boost/histogram/ostream_operators.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_OSTREAM_OPERATORS_HPP_
-#define _BOOST_HISTOGRAM_OSTREAM_OPERATORS_HPP_
+#ifndef BOOST_HISTOGRAM_OSTREAM_OPERATORS_HPP
+#define BOOST_HISTOGRAM_OSTREAM_OPERATORS_HPP
 
 #include <boost/histogram/axis/ostream_operators.hpp>
 #include <boost/histogram/histogram_fwd.hpp>

--- a/include/boost/histogram/serialization.hpp
+++ b/include/boost/histogram/serialization.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef BOOST_HISTOGRAM_SERIALIZATION_HPP_
-#define BOOST_HISTOGRAM_SERIALIZATION_HPP_
+#ifndef BOOST_HISTOGRAM_SERIALIZATION_HPP
+#define BOOST_HISTOGRAM_SERIALIZATION_HPP
 
 #include <boost/container/string.hpp>
 #include <boost/histogram/axis/any.hpp>

--- a/include/boost/histogram/storage/adaptive_storage.hpp
+++ b/include/boost/histogram/storage/adaptive_storage.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_STORAGE_ADAPTIVE_HPP_
-#define _BOOST_HISTOGRAM_STORAGE_ADAPTIVE_HPP_
+#ifndef BOOST_HISTOGRAM_STORAGE_ADAPTIVE_HPP
+#define BOOST_HISTOGRAM_STORAGE_ADAPTIVE_HPP
 
 #include <algorithm>
 #include <boost/assert.hpp>

--- a/include/boost/histogram/storage/array_storage.hpp
+++ b/include/boost/histogram/storage/array_storage.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_STORAGE_ARRAY_HPP_
-#define _BOOST_HISTOGRAM_STORAGE_ARRAY_HPP_
+#ifndef BOOST_HISTOGRAM_STORAGE_ARRAY_HPP
+#define BOOST_HISTOGRAM_STORAGE_ARRAY_HPP
 
 #include <algorithm>
 #include <boost/histogram/detail/meta.hpp>

--- a/include/boost/histogram/storage/operators.hpp
+++ b/include/boost/histogram/storage/operators.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_STORAGE_OPERATORS_HPP_
-#define _BOOST_HISTOGRAM_STORAGE_OPERATORS_HPP_
+#ifndef BOOST_HISTOGRAM_STORAGE_OPERATORS_HPP
+#define BOOST_HISTOGRAM_STORAGE_OPERATORS_HPP
 
 #include <boost/histogram/detail/meta.hpp>
 

--- a/include/boost/histogram/storage/weight_counter.hpp
+++ b/include/boost/histogram/storage/weight_counter.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_STORAGE_WEIGHT_COUNTER_HPP_
-#define _BOOST_HISTOGRAM_STORAGE_WEIGHT_COUNTER_HPP_
+#ifndef BOOST_HISTOGRAM_STORAGE_WEIGHT_COUNTER_HPP
+#define BOOST_HISTOGRAM_STORAGE_WEIGHT_COUNTER_HPP
 
 #include <boost/histogram/weight.hpp>
 #include <stdexcept>

--- a/include/boost/histogram/weight.hpp
+++ b/include/boost/histogram/weight.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_WEIGHT_HPP_
-#define _BOOST_HISTOGRAM_WEIGHT_HPP_
+#ifndef BOOST_HISTOGRAM_WEIGHT_HPP
+#define BOOST_HISTOGRAM_WEIGHT_HPP
 
 namespace boost {
 namespace histogram {

--- a/src/python/serialization_suite.hpp
+++ b/src/python/serialization_suite.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_PYTHON_SERIALIZATION_SUITE_HPP_
-#define _BOOST_HISTOGRAM_PYTHON_SERIALIZATION_SUITE_HPP_
+#ifndef BOOST_HISTOGRAM_PYTHON_SERIALIZATION_SUITE_HPP
+#define BOOST_HISTOGRAM_PYTHON_SERIALIZATION_SUITE_HPP
 
 #include <algorithm>
 #include <boost/archive/text_iarchive.hpp>

--- a/src/python/utility.hpp
+++ b/src/python/utility.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef _BOOST_HISTOGRAM_PYTHON_UTILITY_HPP_
-#define _BOOST_HISTOGRAM_PYTHON_UTILITY_HPP_
+#ifndef BOOST_HISTOGRAM_PYTHON_UTILITY_HPP
+#define BOOST_HISTOGRAM_PYTHON_UTILITY_HPP
 
 #include <boost/python/str.hpp>
 #include <stdexcept>

--- a/test/utility.hpp
+++ b/test/utility.hpp
@@ -4,8 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef BOOST_HISTOGRAM_TEST_UTILITY_HPP_
-#define BOOST_HISTOGRAM_TEST_UTILITY_HPP_
+#ifndef BOOST_HISTOGRAM_TEST_UTILITY_HPP
+#define BOOST_HISTOGRAM_TEST_UTILITY_HPP
 
 #include <boost/histogram/histogram.hpp>
 #include <boost/mp11/integral.hpp>


### PR DESCRIPTION
Remove leading undescore from the macro names, make them legal C++.

-----

Also, [Boost library requirements](https://www.boost.org/development/requirements.html#Design_and_Programming) specify:
> Macro (gasp!) names all uppercase and begin with BOOST_.

So, the clean-up is important from the review perspective as well.
