### PR TITLE
Fix prototype of tracing_allocator::deallocate

### DIFF
--- a/test/utility.hpp
+++ b/test/utility.hpp
@@ -112,7 +112,7 @@ struct tracing_allocator {
     return static_cast<T*>(::operator new(n * sizeof(T)));
   }
 
-  void deallocate(T*& p, std::size_t n) {
+  void deallocate(T* p, std::size_t n) {
     if (db) {
       (*db)[typeid(T)].second += n;
     }


### PR DESCRIPTION
Align the parameter types with `std::allocator::deallocate prototype.
Otherwise, compilation using MSVC 19.15.26729 fails due to unresolved conversion of the first argument from `T* const` to `T*&`

-----

Compilation of `axis_test.cpp` with MSVC 19.15.26729 (VS2017 15.8.4) is failing with

```
...
ClCompile:
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.15.26726\bin\HostX64\x86\CL.exe 
  /c /ID:\boost.win\libs\histogram\build\..\include /ID:\boost.win /Zi /nologo /W3 /WX- /diagnostics:classic /Od /Ob0 /Oy-
  /D WIN32 /D _WINDOWS /D _SCL_SECURE_NO_WARNINGS /D "CMAKE_INTDIR=\"Debug\"" /D _MBCS /Gm- /EHsc /RTC1 /MDd /GS /fp:precise 
  /Zc:wchar_t /Zc:forScope /Zc:inline /GR /Fo"axis_test.dir\Debug\\" /Fd"axis_test.dir\Debug\vc141.pdb" /Gd /TP /analyze- 
  /FC /errorReport:queue D:\boost.win\libs\histogram\test\axis_test.cpp
  axis_test.cpp
c:\program files (x86)\microsoft visual studio\2017\professional\vc\tools\msvc\14.15.26726\include\vector(1505):
  error C2664: 'void boost::histogram::tracing_allocator<axis_type>::deallocate(T *&,size_t)':
    cannot convert argument 1 from 'boost::histogram::axis::any<T1,T2,T3,T4,T5> *const ' to 'T *&'
    [D:\boost.win\libs\histogram\build\_build.vs2017\axis_test.vcxproj]
          with
          [
              T=axis_type
          ]
  c:\program files (x86)\microsoft visual studio\2017\professional\vc\tools\msvc\14.15.26726\include\vector(1505):
    note: Conversion loses qualifiers
  c:\program files (x86)\microsoft visual studio\2017\professional\vc\tools\msvc\14.15.26726\include\vector(1497):
    note: while compiling class template member function
      'void std::vector<axis_type,boost::histogram::tracing_allocator<axis_type>>::_Reallocate_exactly(const unsigned int)'
  c:\program files (x86)\microsoft visual studio\2017\professional\vc\tools\msvc\14.15.26726\include\vector(1522):
    note: see reference to function template instantiation
      'void std::vector<axis_type,boost::histogram::tracing_allocator<axis_type>>::_Reallocate_exactly(const unsigned int)'
        being compiled
  d:\boost.win\libs\histogram\test\axis_test.cpp(462):
    note: see reference to class template instantiation
      'std::vector<axis_type,boost::histogram::tracing_allocator<axis_type>>' being compiled
```
