### PR TITLE
New version of Python script

### DIFF
--- a/test/odr_test.py
+++ b/test/odr_test.py
@@ -1,48 +1,72 @@
+from __future__ import print_function, division
+
 import os
 import sys
 import re
+import glob
 
-this_path = os.path.dirname(__file__)
+try:
+    from pathlib import Path
+except ImportError:
+    Path = None
 
-all_headers = set()
-include_path = this_path + "/../include/"
-for root, dirs, files in os.walk(include_path):
-    for fn in files:
-        fn = root + "/" + fn
-        assert fn.startswith(include_path)
-        fn = fn[len(include_path) :]
-        all_headers.add(fn)
+# Drop when Python2 support is dropped
+if Path is None:
+
+    class Path(str):
+        def __new__(cls, path):
+            return super(cls, Path).__new__(cls, os.path.normpath(path))
+
+        def __truediv__(self, s):
+            return self.__class__(os.path.join(self, s))
+
+        def resolve(self):
+            return self.__class__(os.path.abspath(self))
+
+        def relative_to(self, other):
+            return self.__class__(os.path.relpath(self, other))
+
+        def glob(self, ex):  # Warning: hacky workaround - returns all files
+            for root, _, files in os.walk(self):
+                for f in files:
+                    yield self.__class__(root) / f
+
+        @property
+        def parent(self):
+            return self.__class__(os.path.dirname(self))
+
+
+this_path = Path(__file__).resolve().parent
+
+include_path = this_path.parent / "include"
+all_headers = {f.relative_to(include_path) for f in include_path.glob("**/*.hpp")}
 
 
 def get_headers(filename):
-    with open(filename) as f:
+    with open(str(filename)) as f:
         for hdr in re.findall('^#include [<"]([^>"]+)[>"]', f.read(), re.MULTILINE):
-            if not hdr.startswith("boost/histogram"):
-                continue
-            yield hdr
+            if hdr.startswith("boost/histogram"):
+                yield Path(hdr)
 
 
 included_headers = set()
-unread_headers = set()
-for hdr in get_headers(this_path + "/odr_test.cpp"):
-    unread_headers.add(hdr)
+unread_headers = set(get_headers(this_path / "odr_test.cpp"))
 
 while unread_headers:
     included_headers.update(unread_headers)
     for hdr in tuple(unread_headers):
         unread_headers.remove(hdr)
-        for hdr2 in get_headers(include_path + hdr):
+        for hdr2 in get_headers(include_path / hdr):
             if hdr2 not in included_headers:
                 unread_headers.add(hdr2)
 
-diff = sorted(all_headers - set(included_headers))
+print("Checked", len(all_headers), "headers")
 
-if not diff:
-    sys.exit(0)
+diff = sorted(all_headers - included_headers)
 
+if diff:
+    print("Header not included in odr_test.cpp:")
+    for fn in diff:
+        print(fn)
 
-print("Header not included in odr_test.cpp:")
-for fn in diff:
-    print(fn)
-
-sys.exit(1)
+sys.exit(len(diff))

--- a/test/odr_test.py
+++ b/test/odr_test.py
@@ -8,11 +8,8 @@ import glob
 try:
     from pathlib import Path
 except ImportError:
-    Path = None
 
-# Drop when Python2 support is dropped
-if Path is None:
-
+    # Drop when Python2 support is dropped
     class Path(str):
         def __new__(cls, path):
             return super(cls, Path).__new__(cls, os.path.normpath(path))


### PR DESCRIPTION
Simpler version of Python script, should work on Windows. Test on Python 2 and 3, with and without pathlib. (Prints number of checked headers on success, hopefully that doesn't hurt any checks). Also runs with `python odr_test.py`, while the other required `python ./odr_test.py`. Return code is the number of failed headers.

Note this is a PR into a PR branch, so you can merge then modify if you like.